### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## [Unreleased] - Rascunho do próximo release
-### (Unreleased)
-- Nenhuma alteração documentada ainda.
+## [0.2.1] - 2025-11-05
+### Fixed
+- Corrige um bug na página de pagamento que fazia com que, ao limpar a URL de pagamento, a interface dispare uma requisição desnecessária ao servidor. Agora limpar a URL não aciona requisições; a interface atualiza o estado corretamente e evita chamadas, reduzindo carga no servidor.
 
 ## [0.2.0] - 2025-11-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [Unreleased] - Rascunho do próximo release
+### (Unreleased)
+- Nenhuma alteração documentada ainda.
+
 ## [0.2.0] - 2025-11-04
 ### Added
 - Integração com PagTesouro para criação e consulta de cobranças (cliente HTTP configurado em [backend/api/pagtesouro.js](backend/api/pagtesouro.js)).

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagif-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "engines": {
     "node": ">=20.19.5"

--- a/frontend/app/pages/pagamento/[id].vue
+++ b/frontend/app/pages/pagamento/[id].vue
@@ -115,6 +115,7 @@
             Confira os dados que aparecer&atilde;o na tela abaixo antes de efetuar o pagamento.
           </v-alert>
           <iframe
+            v-if="proximaUrl"
             v-resize-iframe="{ heightCalculationMethod: 'documentElementOffset' }"
             class="iframe-epag"
             scrolling="no"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagif-frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
### Fixed
- Corrige um bug na página de pagamento que fazia com que, ao limpar a URL de pagamento, a interface dispare uma requisição desnecessária ao servidor. Agora limpar a URL não aciona requisições; a interface atualiza o estado corretamente e evita chamadas, reduzindo carga no servidor.